### PR TITLE
Update GitHub Actions to use new version

### DIFF
--- a/.github/workflows/create_release_notice.yml
+++ b/.github/workflows/create_release_notice.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo's default branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Create release notice JSON
         run: python create_output_file.py
       - name: Check if there are any changes


### PR DESCRIPTION
Looks like git checkout has a newer version but didn't want to jump to this as looks like some changes will have to be made